### PR TITLE
Update to Minecraft 1.17, remap and add/modify some access wideners

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,10 @@ task sourcesJar(type: Jar, dependsOn: classes) {
     from sourceSets.main.allSource
 }
 
+java {
+	withSourcesJar()
+}
+
 jar {
     from "LICENSE"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,11 @@ plugins {
     id 'maven-publish'
     id 'idea'
     id 'eclipse'
-    id 'fabric-loom' version '0.2.7-SNAPSHOT'
+    id 'fabric-loom' version '0.8-SNAPSHOT'
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = JavaVersion.VERSION_16
+targetCompatibility = JavaVersion.VERSION_16
 
 archivesBaseName = project.archive_name
 version = project.mod_version
@@ -23,8 +23,8 @@ minecraft {
 dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-    modCompile "net.fabricmc:fabric-loader:${project.loader_version}"
-    modCompile "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	compileOnly "com.google.code.findbugs:jsr305:3.0.2"
 }
@@ -32,14 +32,9 @@ dependencies {
 processResources {
     inputs.property "version", project.version
 
-    from(sourceSets.main.resources.srcDirs) {
-        include "fabric.mod.json"
-        expand "version": project.version
-    }
-
-    from(sourceSets.main.resources.srcDirs) {
-        exclude "fabric.mod.json"
-    }
+	filesMatching("fabric.mod.json") {
+		expand "version": project.version
+	}
 }
 
 tasks.withType(JavaCompile) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 org.gradle.jvmargs=-Xmx1G
 
-mod_version=0.2.3
+mod_version=0.3.0
 maven_group=com.terraformersmc
 archive_name=dossier
 
-minecraft_version=1.16-pre7
-yarn_mappings=1.16-pre7+build.1
-loader_version=0.8.7+build.201
-fabric_version=0.12.4+build.365-1.16
+minecraft_version=1.17
+yarn_mappings=1.17+build.13
+loader_version=0.11.6
+fabric_version=0.36.0+1.17

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx1G
 
-mod_version=0.3.0
+mod_version=0.4.0
 maven_group=com.terraformersmc
 archive_name=dossier
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,7 @@ pluginManagement {
 
 		maven {
 			name = 'SpongePowered'
-			url = 'http://repo.spongepowered.org/maven'
+			url = 'https://repo.spongepowered.org/maven'
 		}
     }
 }

--- a/src/main/java/com/terraformersmc/dossier/generator/RecipesDossier.java
+++ b/src/main/java/com/terraformersmc/dossier/generator/RecipesDossier.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 public abstract class RecipesDossier extends DossierGenerator<DossierRecipesProvider, Consumer<Consumer<RecipeJsonProvider>>> {
 
     protected InventoryChangedCriterion.Conditions conditionsFrom(ItemConvertible item) {
-        return this.conditionsFrom(ItemPredicate.Builder.create().item(item).build());
+        return this.conditionsFrom(ItemPredicate.Builder.create().items(item).build());
     }
 
     protected InventoryChangedCriterion.Conditions conditionsFrom(Tag<Item> tag) {

--- a/src/main/java/com/terraformersmc/dossier/provider/DossierBlockTagsProvider.java
+++ b/src/main/java/com/terraformersmc/dossier/provider/DossierBlockTagsProvider.java
@@ -41,8 +41,8 @@ public class DossierBlockTagsProvider extends AbstractTagProvider<Block> impleme
 	}
 
 	@Override
-	public Tag.Builder method_27169(Tag.Identified<Block> identified) {
-		return super.method_27169(identified);
+	public Tag.Builder getTagBuilder(Tag.Identified<Block> identified) {
+		return super.getTagBuilder(identified);
 	}
 
 	@Override

--- a/src/main/java/com/terraformersmc/dossier/provider/DossierItemTagsProvider.java
+++ b/src/main/java/com/terraformersmc/dossier/provider/DossierItemTagsProvider.java
@@ -20,7 +20,7 @@ public class DossierItemTagsProvider extends AbstractTagProvider<Item> implement
 
 	public DossierItemTagsProvider(DataGenerator generator, DossierBlockTagsProvider blockTagsProvider, String modId) {
 		super(generator, Registry.ITEM);
-		this.tagCopier = blockTagsProvider::method_27169;
+		this.tagCopier = blockTagsProvider::getTagBuilder;
 		this.modId = modId;
 	}
 
@@ -40,7 +40,7 @@ public class DossierItemTagsProvider extends AbstractTagProvider<Item> implement
 	}
 
 	public void copy(Tag.Identified<Block> identified, Tag.Identified<Item> identified2) {
-		Tag.Builder builder = this.method_27169(identified2);
+		Tag.Builder builder = this.getTagBuilder(identified2);
 		Tag.Builder builder2 = this.tagCopier.apply(identified);
 		builder2.streamEntries().forEach(builder::add);
 	}

--- a/src/main/java/com/terraformersmc/dossier/util/BlockLootTableCreator.java
+++ b/src/main/java/com/terraformersmc/dossier/util/BlockLootTableCreator.java
@@ -4,15 +4,15 @@ import net.minecraft.block.Block;
 import net.minecraft.data.server.BlockLootTableGenerator;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemConvertible;
-import net.minecraft.loot.ConstantLootTableRange;
 import net.minecraft.loot.LootPool;
 import net.minecraft.loot.LootTable;
-import net.minecraft.loot.LootTableRange;
+import net.minecraft.loot.provider.number.LootNumberProvider;
 import net.minecraft.loot.condition.LootCondition;
 import net.minecraft.loot.condition.LootConditionConsumingBuilder;
 import net.minecraft.loot.entry.ItemEntry;
 import net.minecraft.loot.entry.LootPoolEntry;
 import net.minecraft.loot.function.LootFunctionConsumingBuilder;
+import net.minecraft.loot.provider.number.ConstantLootNumberProvider;
 import net.minecraft.state.property.Property;
 import net.minecraft.util.StringIdentifiable;
 
@@ -36,7 +36,7 @@ public class BlockLootTableCreator {
 	public static LootTable.Builder drops(LootPoolEntry.Builder<?> entry, LootCondition.Builder conditionBuilder, LootPoolEntry.Builder<?> child) {
 		return LootTable.builder()
 				.pool(LootPool.builder()
-						.rolls(ConstantLootTableRange.create(1))
+						.rolls(ConstantLootNumberProvider.create(1))
 						.with(entry
 								.conditionally(conditionBuilder)
 								.alternatively(child)));
@@ -58,11 +58,11 @@ public class BlockLootTableCreator {
 		return BlockLootTableGenerator.drops(block, lootWithoutSilkTouch);
 	}
 
-	public static LootTable.Builder drops(ItemConvertible item, LootTableRange count) {
+	public static LootTable.Builder drops(ItemConvertible item, LootNumberProvider count) {
 		return BlockLootTableGenerator.drops(item, count);
 	}
 
-	public static LootTable.Builder drops(Block block, ItemConvertible lootWithoutSilkTouch, LootTableRange count) {
+	public static LootTable.Builder drops(Block block, ItemConvertible lootWithoutSilkTouch, LootNumberProvider count) {
 		return BlockLootTableGenerator.drops(block, lootWithoutSilkTouch, count);
 	}
 

--- a/src/main/resources/dossier.accesswidener
+++ b/src/main/resources/dossier.accesswidener
@@ -8,8 +8,8 @@ accessible	method	net/minecraft/data/server/BlockLootTableGenerator	dropsWithSil
 accessible	method	net/minecraft/data/server/BlockLootTableGenerator	dropsWithShears	(Lnet/minecraft/block/Block;Lnet/minecraft/loot/entry/LootPoolEntry$Builder;)Lnet/minecraft/loot/LootTable$Builder;
 accessible	method	net/minecraft/data/server/BlockLootTableGenerator	dropsWithSilkTouchOrShears	(Lnet/minecraft/block/Block;Lnet/minecraft/loot/entry/LootPoolEntry$Builder;)Lnet/minecraft/loot/LootTable$Builder;
 accessible	method	net/minecraft/data/server/BlockLootTableGenerator	drops	(Lnet/minecraft/block/Block;Lnet/minecraft/item/ItemConvertible;)Lnet/minecraft/loot/LootTable$Builder;
-accessible	method	net/minecraft/data/server/BlockLootTableGenerator	drops	(Lnet/minecraft/item/ItemConvertible;Lnet/minecraft/loot/LootTableRange;)Lnet/minecraft/loot/LootTable$Builder;
-accessible	method	net/minecraft/data/server/BlockLootTableGenerator	drops	(Lnet/minecraft/block/Block;Lnet/minecraft/item/ItemConvertible;Lnet/minecraft/loot/LootTableRange;)Lnet/minecraft/loot/LootTable$Builder;
+accessible	method	net/minecraft/data/server/BlockLootTableGenerator	drops	(Lnet/minecraft/block/Block;Lnet/minecraft/item/ItemConvertible;Lnet/minecraft/loot/provider/number/LootNumberProvider;)Lnet/minecraft/loot/LootTable$Builder;
+accessible  method  net/minecraft/data/server/BlockLootTableGenerator   drops   (Lnet/minecraft/item/ItemConvertible;Lnet/minecraft/loot/provider/number/LootNumberProvider;)Lnet/minecraft/loot/LootTable$Builder;
 accessible	method	net/minecraft/data/server/BlockLootTableGenerator	dropsWithSilkTouch	(Lnet/minecraft/item/ItemConvertible;)Lnet/minecraft/loot/LootTable$Builder;
 accessible	method	net/minecraft/data/server/BlockLootTableGenerator	pottedPlantDrops	(Lnet/minecraft/item/ItemConvertible;)Lnet/minecraft/loot/LootTable$Builder;
 accessible	method	net/minecraft/data/server/BlockLootTableGenerator	slabDrops	(Lnet/minecraft/block/Block;)Lnet/minecraft/loot/LootTable$Builder;
@@ -22,3 +22,4 @@ accessible	method	net/minecraft/data/server/BlockLootTableGenerator	attachedCrop
 accessible	method	net/minecraft/data/server/BlockLootTableGenerator	dropsWithShears	(Lnet/minecraft/item/ItemConvertible;)Lnet/minecraft/loot/LootTable$Builder;
 accessible	method	net/minecraft/data/server/BlockLootTableGenerator	leavesDrop	(Lnet/minecraft/block/Block;Lnet/minecraft/block/Block;[F)Lnet/minecraft/loot/LootTable$Builder;
 accessible	method	net/minecraft/data/server/BlockLootTableGenerator	cropDrops	(Lnet/minecraft/block/Block;Lnet/minecraft/item/Item;Lnet/minecraft/item/Item;Lnet/minecraft/loot/condition/LootCondition$Builder;)Lnet/minecraft/loot/LootTable$Builder;
+accessible  class   net/minecraft/data/server/AbstractTagProvider$ObjectBuilder

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,6 +23,7 @@
     "TerraformersMC"
   ],
   "contributors": [
+    "jhbuchanan45"
   ],
   "description": "Data Generation library for Terraformers",
   "custom": {


### PR DESCRIPTION
I've updated the dependencies and fixed the various build errors for 1.17. (Mostly changing LootTableRange -> LootNumberProvider and the fabric-loom remapping)

I have some free time, so I'm going to try and work on this and Campanions to see if I can get them working on 1.17. I _don't_ know if this works correctly when being used by a mod, only that the build has no errors, but if I find anything with Campanion I'll push updates